### PR TITLE
fix: resolve incompatible pointer type errors in sign.c

### DIFF
--- a/c_src/sign.c
+++ b/c_src/sign.c
@@ -39,7 +39,7 @@ int ed25519_sign(unsigned char *signature, const unsigned char *message, size_t 
     Sha512Update(&hash, signature, 32);
     Sha512Update(&hash, private_key+32, 32);
     Sha512Update(&hash, message, message_len);
-    Sha512Finalise(&hash, hram);
+    Sha512Finalise(&hash, (SHA512_HASH *)hram);
 
     sc_reduce(hram);
     sc_muladd(signature + 32, hram, expanded_secret_key, reduce);
@@ -78,7 +78,7 @@ int ed25519_sign_bytom(unsigned char *signature, const unsigned char *message, s
     ge_p3_tobytes(encodedR, &R);
 
     unsigned char public_key[32];  //private_key to publicKey
-    ed25519_public_key(public_key, private_key);
+    ed25519_public_key(public_key, (unsigned char *)private_key);
     Sha512Initialise(&hash);
     Sha512Update(&hash, encodedR, 32);
     Sha512Update(&hash, public_key, 32);


### PR DESCRIPTION
修复在 OTP27 下的编译报错

- Cast hram to SHA512_HASH* for Sha512Finalise call (line 42) SHA512_HASH has identical memory layout to unsigned char[64], so this cast is safe at runtime.
- Cast const private_key to unsigned char* for ed25519_public_key (line 81) — the function only reads the key internally.

Both fixes are compile-time only, no behavior change.

在本地已通过测试。

## 报错信息

```
make: Entering directory '/app/deps/ed25519/c_src'
cc -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes -fPIC -I /usr/local/lib/erlang/erts-15.2.7.8/include/ -I /usr/local/lib/erlang/lib/erl_interface-5.5.2/include  -c -o /app/deps/ed25519/c_src/verify.o /app/deps/ed25519/c_src/verify.c
cc -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes -fPIC -I /usr/local/lib/erlang/erts-15.2.7.8/include/ -I /usr/local/lib/erlang/lib/erl_interface-5.5.2/include  -c -o /app/deps/ed25519/c_src/add_scalar.o /app/deps/ed25519/c_src/add_scalar.c
cc -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes -fPIC -I /usr/local/lib/erlang/erts-15.2.7.8/include/ -I /usr/local/lib/erlang/lib/erl_interface-5.5.2/include  -c -o /app/deps/ed25519/c_src/sha512.o /app/deps/ed25519/c_src/sha512.c
cc -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes -fPIC -I /usr/local/lib/erlang/erts-15.2.7.8/include/ -I /usr/local/lib/erlang/lib/erl_interface-5.5.2/include  -c -o /app/deps/ed25519/c_src/sc.o /app/deps/ed25519/c_src/sc.c
cc -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes -fPIC -I /usr/local/lib/erlang/erts-15.2.7.8/include/ -I /usr/local/lib/erlang/lib/erl_interface-5.5.2/include  -c -o /app/deps/ed25519/c_src/key_exchange.o /app/deps/ed25519/c_src/key_exchange.c
cc -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes -fPIC -I /usr/local/lib/erlang/erts-15.2.7.8/include/ -I /usr/local/lib/erlang/lib/erl_interface-5.5.2/include  -c -o /app/deps/ed25519/c_src/seed.o /app/deps/ed25519/c_src/seed.c
cc -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes -fPIC -I /usr/local/lib/erlang/erts-15.2.7.8/include/ -I /usr/local/lib/erlang/lib/erl_interface-5.5.2/include  -c -o /app/deps/ed25519/c_src/fe.o /app/deps/ed25519/c_src/fe.c
cc -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes -fPIC -I /usr/local/lib/erlang/erts-15.2.7.8/include/ -I /usr/local/lib/erlang/lib/erl_interface-5.5.2/include  -c -o /app/deps/ed25519/c_src/ed25519_nifs.o /app/deps/ed25519/c_src/ed25519_nifs.c
cc -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes -fPIC -I /usr/local/lib/erlang/erts-15.2.7.8/include/ -I /usr/local/lib/erlang/lib/erl_interface-5.5.2/include  -c -o /app/deps/ed25519/c_src/sign.o /app/deps/ed25519/c_src/sign.c
/app/deps/ed25519/c_src/sign.c: In function 'ed25519_sign':
/app/deps/ed25519/c_src/sign.c:42:27: error: passing argument 2 of 'Sha512Finalise' from incompatible pointer type [-Wincompatible-pointer-types]
   42 |     Sha512Finalise(&hash, hram);
      |                           ^~~~
      |                           |
      |                           unsigned char *
In file included from /app/deps/ed25519/c_src/sign.c:2:
/app/deps/ed25519/c_src/sha512.h:74:29: note: expected 'SHA512_HASH *' but argument is of type 'unsigned char *'
   74 |         SHA512_HASH*        Digest          // [out]
      |         ~~~~~~~~~~~~~~~~~~~~^~~~~~
/app/deps/ed25519/c_src/sign.c: In function 'ed25519_sign_bytom':
/app/deps/ed25519/c_src/sign.c:81:36: warning: passing argument 2 of 'ed25519_public_key' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
   81 |     ed25519_public_key(public_key, private_key);
      |                                    ^~~~~~~~~~~
In file included from /app/deps/ed25519/c_src/sign.c:1:
/app/deps/ed25519/c_src/ed25519.h:28:83: note: expected 'unsigned char *' but argument is of type 'const unsigned char *'
   28 | int ED25519_DECLSPEC ed25519_public_key(unsigned char *public_key, unsigned char *private_key);
      |                                                                    ~~~~~~~~~~~~~~~^~~~~~~~~~~
make: *** [Makefile:62: /app/deps/ed25519/c_src/sign.o] Error 1
make: Leaving directory '/app/deps/ed25519/c_src'
```